### PR TITLE
Fill: Extend fill lines by 1px for galleries with 800x600 canvases

### DIFF
--- a/src/sketch-canvas/sketch-canvas.html
+++ b/src/sketch-canvas/sketch-canvas.html
@@ -540,11 +540,13 @@
         if (this.toneSpacing > 3) {
           linePoints = this.$.data.toneArea(flood.bounds, flood.mask, this.toneSpacing);
         } else {
+          // Extend fill lines by 1px to make ends visible on gallery-style rendering
+          var lines = flood.lines.map((l) => [l[0], l[1], l[2] + 1, l[3]]);
           if (this.toneSpacing > 1) {
             // Poor's man hashing... for now
-            linePoints = flood.lines.filter((l, i) => l[1] % (this.toneSpacing*2) == 0);
+            linePoints = lines.filter((l, i) => l[1] % (this.toneSpacing*2) == 0);
           } else {
-            linePoints = flood.lines;
+            linePoints = lines;
           }
           this.$.data.drawLines(linePoints);
         }


### PR DESCRIPTION
Clients like Noz that fix the gallery canvas's resolution from 798x598 to the proper 800x600 would show a 1px whitespace at the right for fills, caused by the gallery's line cap. Extending generated fill lines by 1px can cover it up, and clipping wouldn't affect it.

Whitespace in question:

![image](https://user-images.githubusercontent.com/49148994/170976399-167be0af-cfbf-49cf-adf5-72c8eb87c83d.png "#7131476")